### PR TITLE
chore: add `shx` to Dev dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/turndown": "^5.0.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "shx": "0.4.0"
   }
 }


### PR DESCRIPTION
# Overview

When installing the MCP from VSCode cline, the install process fails because the `shx` dependancy isn't declared in the `package.json` file. This has been reported in #9 . 

This change adds the dependancy in and just pins it to `0.4.0`, which currently is the latest version.

## Testing

```bash
fetch-mcp on  main [?] is 📦 v1.0.0 via  v22.13.1 took 11s 
❯ npm i

> fetch@1.0.0 prepare
> npm run build


> fetch@1.0.0 build
> tsc && shx chmod +x dist/*.js

sh: shx: command not found
npm error code 127
npm error path /Users/person/Documents/Cline/MCP/fetch-mcp
npm error command failed
npm error command sh -c npm run build
npm error A complete log of this run can be found in: /Users/person/.npm/_logs/2025-04-08T14_16_21_602Z-debug-0.log

fetch-mcp on  main [?] is 📦 v1.0.0 via  v22.13.1 
❯ vim package.json 

fetch-mcp on  main [?] is 📦 v1.0.0 via  v22.13.1 
❯ cat package.json 
{
  "name": "fetch",
  "version": "1.0.0",
  "description": "",
  "type": "module",
  "main": "index.js",
  "license": "MIT",
  "author": "zcaceres (@zachcaceres zach.dev)",
  "scripts": {
    "build": "tsc && shx chmod +x dist/*.js",
    "prepare": "npm run build",
    "dev": "tsc --watch",
    "start": "node dist/index.js",
    "test": "jest"
  },
  "keywords": [],
  "dependencies": {
    "@modelcontextprotocol/sdk": "^1.0.4",
    "jsdom": "^25.0.1",
    "turndown": "^7.2.0",
    "zod": "^3.24.1"
  },
  "devDependencies": {
    "@types/jest": "^29.5.14",
    "@types/jsdom": "^21.1.7",
    "@types/node": "^22.10.2",
    "@types/turndown": "^5.0.5",
    "jest": "^29.7.0",
    "ts-jest": "^29.2.5",
    "typescript": "^5.7.2",
    "shx": "0.4.0"
  }
}


fetch-mcp on  main [!?] is 📦 v1.0.0 via  v22.13.1 took 31s 
❯ npm i

> fetch@1.0.0 prepare
> npm run build


> fetch@1.0.0 build
> tsc && shx chmod +x dist/*.js


added 32 packages, and audited 431 packages in 2s

59 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

fetch-mcp on  main [!?] is 📦 v1.0.0 via  v22.13.1 took 2s 
❯ npm run build

> fetch@1.0.0 build
> tsc && shx chmod +x dist/*.js
```