### PR TITLE
Replace readability + turndown with readdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "bun build src/index.ts src/cli.ts --outdir dist --target node --external jsdom --external @mozilla/readability --external turndown",
+    "build": "bun build src/index.ts src/cli.ts --outdir dist --target node --external jsdom --external readdown",
     "prepublishOnly": "bun run build",
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
@@ -48,16 +48,13 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@mozilla/readability": "^0.6.0",
     "jsdom": "^28.1.0",
     "private-ip": "^3.0.2",
-    "turndown": "^7.2.2",
+    "readdown": "github:zcag/readdown",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/jsdom": "^28.0.0",
-    "@types/mozilla__readability": "^0.4.2",
-    "@types/turndown": "^5.0.6"
+    "@types/jsdom": "^28.0.0"
   }
 }

--- a/src/Fetcher.ts
+++ b/src/Fetcher.ts
@@ -1,6 +1,5 @@
 import { JSDOM } from "jsdom";
-import TurndownService from "turndown";
-import { Readability } from "@mozilla/readability";
+import { readdown } from "readdown";
 import is_ip_private from "private-ip";
 import dns from "node:dns";
 import { RequestPayload, YouTubeTranscriptPayload, downloadLimit, maxResponseBytes } from "./types.js";
@@ -321,16 +320,8 @@ export class Fetcher {
       const response = await this._fetch(requestPayload);
       const html = await this.readResponseText(response);
 
-      const dom = new JSDOM(html, { url: requestPayload.url });
-      const reader = new Readability(dom.window.document);
-      const article = reader.parse();
-
-      if (!article) {
-        throw new Error("Failed to parse readable content from the page");
-      }
-
-      const turndownService = new TurndownService();
-      let content = turndownService.turndown(article.content ?? "");
+      const result = readdown(html, { url: requestPayload.url, includeHeader: false });
+      let content = result.markdown;
 
       content = this.applyLengthLimits(
         content,
@@ -351,9 +342,9 @@ export class Fetcher {
     try {
       const response = await this._fetch(requestPayload);
       const html = await this.readResponseText(response);
-      const turndownService = new TurndownService();
-      let markdown = turndownService.turndown(html);
-      
+      const result = readdown(html, { url: requestPayload.url, includeHeader: false, raw: true });
+      let markdown = result.markdown;
+
       // Apply length limits
       markdown = this.applyLengthLimits(
         markdown,


### PR DESCRIPTION
## Summary

Replaces the `@mozilla/readability` + `turndown` two-package pipeline with [`readdown`](https://github.com/zcag/readdown), a single dependency that handles both content extraction and Markdown conversion.

**Changes:**
- `src/Fetcher.ts`: `readable()` and `markdown()` methods now use `readdown()` instead of JSDOM+Readability+TurndownService
- `package.json`: Removed `@mozilla/readability`, `turndown`, `@types/mozilla__readability`, `@types/turndown`; added `readdown`

**Benefits:**
- **2 dependencies → 1** — simpler dependency tree, fewer potential conflicts
- **Better heading extraction** — readdown preserves full document structure (h1-h6) that readability often misses
- **~40% faster** on most pages ([benchmarks](https://github.com/zcag/readdown#benchmarks))
- **Built-in token estimation** available via `result.tokens` if needed in the future
- **Cleaner API** — single function call replaces multi-step JSDOM→Readability→Turndown pipeline

**Note:** readdown is currently installed from GitHub (`github:zcag/readdown`). Once published to npm, this can be switched to a versioned `"readdown": "^x.x.x"` dependency.

## Test plan

- [ ] `bun run build` compiles successfully (verified locally)
- [ ] Test `readable` mode against a few article URLs
- [ ] Test `markdown` mode against various HTML pages
- [ ] Verify length limits (`max_length`, `start_index`) still work correctly
- [ ] Verify `txt` and `html` modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)